### PR TITLE
Fixed meta description and canonical

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,11 +2,10 @@
 title: Python Brasil 11
 email: your-email@domain.com
 description: > # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
+  11ª Conferência Brasileira da Comunidade Python. Cinco dias de
+  Tutoriais, palestras e sprints sobre a linguagem Python.
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "http://yourdomain.com" # the base hostname & protocol for your site
+url: "http://pythonbrasil.github.io/pythonbrasil11-site" # the base hostname & protocol for your site
 twitter_username: jekyllrb
 github_username:  jekyll
 

--- a/_site/index.html
+++ b/_site/index.html
@@ -7,11 +7,11 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <title>Python Brasil 11</title>
-  <meta name="description" content="Write an awesome description for your new site here. You can edit this line in _config.yml. It will appear in your document head meta (for Google search results) and in your feed.xml site description.
+  <meta name="description" content="11ª Conferência Brasileira da Comunidade Python. Cinco dias de Tutoriais, palestras e sprints sobre a linguagem Python.
 ">
 
   <link rel="stylesheet" href="css/main.css">
-  <link rel="canonical" href="http://yourdomain.com/">
+  <link rel="canonical" href="http://pythonbrasil.github.io/pythonbrasil11-site/">
 </head>
 
 


### PR DESCRIPTION
Quando compartilhamos o link no slack ou no facebook a msg que aparece é `Write an awesome description for your new site here. You can edit this line in _config.yml. It will appear in your document head meta (for Google search results) and in your feed.xml site description.`

Esse MR corrige isso. 
